### PR TITLE
Add support for incident links to the incident service

### DIFF
--- a/incident/result.go
+++ b/incident/result.go
@@ -18,6 +18,7 @@ type Incident struct {
 	OwnerTeam       string            `json:"ownerTeam"`
 	Responders      []Responder       `json:"responders"`
 	ExtraProperties map[string]string `json:"extraProperties"`
+	Links           IncidentLinks     `json:"links"`
 }
 
 type RequestStatusResult struct {
@@ -79,4 +80,11 @@ type Paging struct {
 	Prev  string `json:"prev"`
 	First string `json:"first"`
 	Last  string `json:"last"`
+}
+
+// This is an undocumented part of the response, but is very important for us as it's the only way we
+// can get the web link to the incident.
+type IncidentLinks struct {
+	Web string `json:"web"`
+	API string `json:"api"`
 }


### PR DESCRIPTION
This is an undocumented field on the opsgenie incidents API, which we need so that we can get the web URL for an incident.